### PR TITLE
Add python3-dev dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ RUN \
 		pciutils-dev \
 		python \
 		python-dev \
+		python3-dev \
 		python-twisted \
 		texinfo \
 		texlive-fonts-extra \


### PR DESCRIPTION
When running ./configure on new versions you get:
`configure: error: Unable to find Python development headers`